### PR TITLE
This patch adds the basic support for UnrealIRCD v4.

### DIFF
--- a/configure
+++ b/configure
@@ -2469,7 +2469,7 @@ fi
 
 # Define the identity of the package.
  PACKAGE='child'
- VERSION='1.4-svn'
+ VERSION='1.4-unreal4'
 
 
 cat >>confdefs.h <<_ACEOF

--- a/include/commands.h
+++ b/include/commands.h
@@ -166,6 +166,7 @@ void m_eos ();
 void m_join (char *, char *);
 void m_kick (char *, char *);
 void m_kill (char *, char *);
+void m_umode (char *, char *);
 void m_mode (char *, char *);
 void m_nick (char *, char *);
 void m_part (char *, char *);

--- a/include/user.h
+++ b/include/user.h
@@ -150,7 +150,7 @@ typedef struct nick {
     char nick[NICKLEN + 1]; /* hash key */
     char ident[NICKLEN + 1];
     char host[HOSTLEN + 1];
-    char server[HOSTLEN + 1];
+    char uid[HOSTLEN + 1];
     char hiddenhost[HOSTLEN + 1];
     char reshost[HOSTLEN + 1];
     long int umodes;

--- a/src/channel.c
+++ b/src/channel.c
@@ -386,7 +386,7 @@ void JoinChannel (char *who, char *name)
         return;
 
     SendRaw(":%s JOIN %s",who,name);
-    SendRaw("MODE %s +ao %s %s",name,who,who);
+    SendRaw(":%s MODE %s +ao %s %s",who,name,who,who);
 }
 
 Member *find_member (char *chname, char *name)

--- a/src/modules/secserv.c
+++ b/src/modules/secserv.c
@@ -263,7 +263,7 @@ int check_nick(Nick *nptr)
     char *nick = nptr->nick;
     if (!nick || *nick == '\0') return MOD_CONTINUE;
 
-    if (!Strcmp(nptr->server,"research.geeknode.org")) return MOD_CONTINUE;
+    /*if (!Strcmp(nptr->server,"research.geeknode.org")) return MOD_CONTINUE;*/
 
     if (seclev == 4) {
         killuser(nick,"We are undergoing a clones attack. New connections are currently denied, please try again later.",me.nick);

--- a/src/net.c
+++ b/src/net.c
@@ -278,8 +278,9 @@ int ConnectToServer()
 
 inline void SendInitToServer()
 {
-    SendRaw("PROTOCTL NICKv2 VHP NICKIP");
+    SendRaw("PROTOCTL NICKv2 VHP NICKIP ESVID");
     SendRaw("PASS :%s",me.linkpass);
+    SendRaw("PROTOCTL EAUTH=%s SID=123",me.name);
     SendRaw("SERVER %s 1 :Child IRC Services",me.name);
     SendRaw("SQLINE %s :Reserved for services",me.nick);
     fakeuser(me.nick,me.ident,me.host,MY_UMODES);

--- a/src/user.c
+++ b/src/user.c
@@ -35,9 +35,11 @@ User *find_user(char *name)
 Nick *find_nick(char *name)
 {
     Nick *tmp;
-    LIST_FOREACH(nick_list, tmp, HASH(name)) {
-        if (!Strcmp(tmp->nick,name))
+
+    LIST_FOREACH_ALL(nick_list, tmp) {
+        if (!Strcmp(tmp->nick,name) || !Strcmp(tmp->uid,name)) {
             return tmp;
+	}
     }
 
     return NULL;
@@ -109,7 +111,7 @@ User *AddUser (char *nick, int level)
     return new_user;
 }
 
-Nick *AddNick(char *nick, char *ident, char *host, char *server, char *hiddenhost, long int umodes, char *reshost)
+Nick *AddNick(char *nick, char *ident, char *host, char *uid, char *hiddenhost, long int umodes, char *reshost)
 {
     Nick *new_nick;
 
@@ -118,7 +120,7 @@ Nick *AddNick(char *nick, char *ident, char *host, char *server, char *hiddenhos
     strncpy(new_nick->nick,nick,NICKLEN);
     strncpy(new_nick->ident,ident,NICKLEN);
     strncpy(new_nick->host,host,HOSTLEN);
-    strncpy(new_nick->server,server,HOSTLEN);
+    strncpy(new_nick->uid,uid,HOSTLEN);
     strncpy(new_nick->hiddenhost,hiddenhost,HOSTLEN);
     strncpy(new_nick->reshost,reshost,HOSTLEN);
     new_nick->umodes = umodes;
@@ -139,7 +141,7 @@ Nick *AddNick(char *nick, char *ident, char *host, char *server, char *hiddenhos
         LIST_INSERT_HEAD(clones_list, clone, HASH(reshost));
     }
 
-    LIST_INSERT_HEAD(nick_list, new_nick, HASH(nick));
+    LIST_INSERT_HEAD(nick_list, new_nick, HASH(uid));
 
     return new_nick;
 }
@@ -197,7 +199,7 @@ inline void DeleteAccount (User *user)
 void DeleteWildNick (Nick *nptr)
 {
     Clone *clone;
-    LIST_REMOVE(nick_list, nptr, HASH(nptr->nick));
+    LIST_REMOVE(nick_list, nptr, HASH(nptr->uid));
     if ((clone = find_clone(nptr->reshost)) != NULL) {
         clone->count--;
         if (clone->count == 0) {


### PR DESCRIPTION
- As UnrealIRCD v4 now uses SID/UID, commands can now arrive using
the nick OR the uid. To support this the nick_list is now hashed
on the uid and the find_nick() now checks the uid AND the nick.

- The NICK function used to introduce new users has been replaced
by UID, making this version not comptaible with UnrealIRCD < 4.

- Adding support for the UMODE2 command, used when a user changes
his usermodes (ex: becoming IRCop)

- All RAW commands used to set channel modes are now prefixed with
the nick of the bot (the bot will set the mode, not the server).

- Specific version added -unreal4