### PR TITLE
fix setting mode +r on users (SVS2MODE) and properly authenticate the…

### DIFF
--- a/src/modules/m_nick.c
+++ b/src/modules/m_nick.c
@@ -338,7 +338,8 @@ void nick_identify (Nick *nptr, User *uptr __unused, char *all)
         NoticeToUser(nptr,"Please set a valid email address with /msg C nick set email email@domain.xx");
 
     user->lastseen = time(NULL);
-    SendRaw("SVSMODE %s +r",nptr->nick);
+    SendRaw("SVS2MODE %s +r",nptr->nick);
+    SendRaw("SVSLOGIN * %s %s",nptr->nick,nptr->nick);
     if (user->vhost[0] != '\0') {
         SendRaw("CHGHOST %s %s",nptr->nick,user->vhost);
         strncpy(nptr->hiddenhost, user->vhost, HOSTLEN);


### PR DESCRIPTION
…m to their nick

I notice you don't seem to have any grouping or logging in as a nick you are not, so it's probably safe to say their account is their nick