### PR TITLE
protocol: SVS2MODE +d on login

### DIFF
--- a/src/modules/m_nick.c
+++ b/src/modules/m_nick.c
@@ -338,7 +338,8 @@ void nick_identify (Nick *nptr, User *uptr __unused, char *all)
         NoticeToUser(nptr,"Please set a valid email address with /msg C nick set email email@domain.xx");
 
     user->lastseen = time(NULL);
-    SendRaw("SVSMODE %s +r",nptr->nick);
+    SendRaw("SVS2MODE %s +r",nptr->nick);
+    SendRaw("SVS2MODE %s +d %s",nptr->nick,nptr->nick);
     if (user->vhost[0] != '\0') {
         SendRaw("CHGHOST %s %s",nptr->nick,user->vhost);
         strncpy(nptr->hiddenhost, user->vhost, HOSTLEN);
@@ -426,6 +427,7 @@ void nick_register (Nick *nptr, User *uptr, char *all)
     } else {        
         user->authed = 1;
         SendRaw("SVSMODE %s +r",nptr->nick);
+        SendRaw("SVSMODE %s +d %s",nptr->nick,nptr->nick);
     }
 }
 


### PR DESCRIPTION
Starting with 5.2.1, unrealircd expects logged in users to have +d set.

> We now assume all services set the SVID field. If your services only
sets umode +r and does not use SVSLOGIN or SVSMODE nick +d SVID then
users will not be recognized as authenticated anymore.

https://github.com/unrealircd/unrealircd/blob/unreal52/doc/RELEASE-NOTES.md

This PR supersedes and closes #11.