### PR TITLE
docker: Switch base to rikorose/gcc-cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM gcc:7.5
+FROM rikorose/gcc-cmake:gcc-9
 
 RUN apt-get update \
-    && apt-get -y install cmake check libssl1.1 libmariadb3 libc6 netcat gdb gdbserver \
+    && apt-get -y install check libssl1.1 libmariadb3 libc6 netcat gdb gdbserver \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Change introduced to CI in 94be09e. This bumps gcc to version 9 as well
as CMake to 3.17.