### PR TITLE
timers: properly initialize expired_check and savedb timers

### DIFF
--- a/src/child.c
+++ b/src/child.c
@@ -367,6 +367,13 @@ int main(int argc, char **argv)
     }
     write_pid();
 
+    // Initialize timers.
+    gettimeofday(&core->next_expired_check_time, NULL);
+    core->next_expired_check_time.tv_sec += 60;
+
+    gettimeofday(&core->next_savedb_time, NULL);
+    core->next_savedb_time.tv_sec += 60*core_get_config()->savedb_interval;
+    
     child_run_loop();
 
     operlog("Returned from main run loop, gracefully exiting.");


### PR DESCRIPTION
All timers are zero-initialized by init_core(), which causes timerisset() to return false.
This prevented the periodic checkexpired() and savealldb() from being triggered.