### PR TITLE
channel: Fix use-after-free when a chan becomes empty

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -363,11 +363,13 @@ void DeleteUserFromWchan (Nick *nptr, Wchan *chan)
 
     DeleteMember(member);
 
-    if (!member_exists(chan)) DeleteWchan(chan);
-
-    Chan *chptr = find_channel(chan->chname);
-    if (chptr && chptr->autolimit > 0)
-        AddLimit(chptr);
+    if (!member_exists(chan)) {
+        DeleteWchan(chan);
+    } else {
+        Chan *chptr = find_channel(chan->chname);
+        if (chptr && chptr->autolimit > 0)
+            AddLimit(chptr);
+    }
 }
 
 void DeleteMember (Member *member)


### PR DESCRIPTION
Discovered using `-fsanitize=address`:
```
==1==ERROR: AddressSanitizer: heap-use-after-free on address 0x6130000003c0 at pc 0x7ff00262ae08 bp 0x7fff7e7a22e0 sp 0x7fff7e7a1a90
READ of size 2 at 0x6130000003c0 thread T0
    #0 0x7ff00262ae07  (/usr/local/lib64/libasan.so.5+0x67e07)
    #1 0x41146d in hash_str_nocase /opt/child/src/core.c:32
    #2 0x416356 in hashmap_bucket /opt/child/src/hashmap.c:53
    #3 0x416356 in hashmap_find /opt/child/src/hashmap.c:143
    #4 0x409b95 in find_channel /opt/child/src/channel.c:45
    #5 0x40b782 in DeleteUserFromWchan /opt/child/src/channel.c:368
    #6 0x40b782 in DeleteUserFromWchan /opt/child/src/channel.c:359
    #7 0x40c50d in DeleteUserFromWchans /opt/child/src/channel.c:497
    #8 0x428320 in userquit /opt/child/src/user.c:386
    #9 0x4229e7 in parse_line /opt/child/src/parseline.c:110
    #10 0x40788c in child_run_loop_once /opt/child/src/child.c:184
    #11 0x40788c in child_run_loop /opt/child/src/child.c:219
    #12 0x40788c in main /opt/child/src/child.c:377
    #13 0x7ff00208a09a in __libc_start_main ../csu/libc-start.c:308
    #14 0x408719 in _start (/opt/child/src/child+0x408719)

0x6130000003c0 is located 0 bytes inside of 368-byte region [0x6130000003c0,0x613000000530)
freed by thread T0 here:
    #0 0x7ff0026ccea7 in __interceptor_free (/usr/local/lib64/libasan.so.5+0x109ea7)
    #1 0x40b7cf in DeleteUserFromWchan /opt/child/src/channel.c:366

previously allocated by thread T0 here:
    #0 0x7ff0026cd43e in __interceptor_calloc (/usr/local/lib64/libasan.so.5+0x10a43e)
    #1 0x40a1a8 in CreateWchan /opt/child/src/channel.c:184

SUMMARY: AddressSanitizer: heap-use-after-free (/usr/local/lib64/libasan.so.5+0x67e07)
Shadow bytes around the buggy address:
  0x0c267fff8020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c267fff8030: 00 fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c267fff8040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c267fff8050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c267fff8060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
=>0x0c267fff8070: fa fa fa fa fa fa fa fa[fd]fd fd fd fd fd fd fd
  0x0c267fff8080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c267fff8090: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c267fff80a0: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x0c267fff80b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c267fff80c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==1==ABORTING
```